### PR TITLE
Add warnings for prebuilt llvm-config to build.rs

### DIFF
--- a/crates/rustc_codegen_nvvm/build.rs
+++ b/crates/rustc_codegen_nvvm/build.rs
@@ -75,6 +75,9 @@ fn find_llvm_config(target: &str) -> PathBuf {
             if version.starts_with(&REQUIRED_MAJOR_LLVM_VERSION.to_string()) {
                 return PathBuf::from(path_to_try);
             }
+            println!("cargo:warning=Prebuilt llvm-config version does not start with {}", REQUIRED_MAJOR_LLVM_VERSION);
+        } else {
+            println!("cargo:warning=Failed to run prebuilt llvm-config");
         }
     }
 


### PR DESCRIPTION
I had some issues with building the wrong llvm version. I just wanted to add some warnings to ensure that no one else will build the wrong version or incorrectly set their `LLVM_CONFIG` environment variable. 